### PR TITLE
Fix stop start issue

### DIFF
--- a/aws-synthetics-canary/aws-synthetics-canary.json
+++ b/aws-synthetics-canary/aws-synthetics-canary.json
@@ -1,7 +1,7 @@
 {
     "typeName": "AWS::Synthetics::Canary",
     "description": "Resource Type definition for AWS::Synthetics::Canary",
-    "sourceUrl": "https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/resource-type-walkthrough.html",
+    "sourceUrl": "https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-synthetics",
     "properties": {
         "Name": {
             "description": "Name of the canary.",

--- a/aws-synthetics-canary/src/main/java/com/amazon/synthetics/canary/CallbackContext.java
+++ b/aws-synthetics-canary/src/main/java/com/amazon/synthetics/canary/CallbackContext.java
@@ -26,6 +26,9 @@ public class CallbackContext {
     private boolean canaryDeleteStarted;
     private boolean canaryDeleteStabilized;
 
+    private boolean canaryStopStarted;
+    private boolean canaryStopStabilized;
+
     @JsonPOJOBuilder(withPrefix = "")
     public static class CallbackContextBuilder {
     }

--- a/aws-synthetics-canary/src/test/java/com/amazon/synthetics/canary/CreateHandlerTest.java
+++ b/aws-synthetics-canary/src/test/java/com/amazon/synthetics/canary/CreateHandlerTest.java
@@ -22,8 +22,6 @@ import static org.mockito.Mockito.mock;
 
 @ExtendWith(MockitoExtension.class)
 public class CreateHandlerTest extends TestBase{
-    private static String EXPECTED_TIMEOUT_MESSAGE = "Timed out waiting for the canary to become available";
-
     @Mock
     private AmazonWebServicesClientProxy proxy;
 

--- a/aws-synthetics-canary/src/test/java/com/amazon/synthetics/canary/DeleteHandlerTest.java
+++ b/aws-synthetics-canary/src/test/java/com/amazon/synthetics/canary/DeleteHandlerTest.java
@@ -11,7 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 @ExtendWith(MockitoExtension.class)
-public class DeleteHandlerTest {
+public class DeleteHandlerTest extends TestBase{
     DeleteHandler handler;
 
     @Mock
@@ -39,7 +39,9 @@ public class DeleteHandlerTest {
 
         final CallbackContext callbackContext = CallbackContext.builder()
                 .canaryDeleteStarted(true)
-                .canaryDeleteStabilized(true).build();
+                .canaryDeleteStabilized(true)
+                .canaryStopStarted(true)
+                .canaryStopStabilized(true).build();
 
         final ProgressEvent<ResourceModel, CallbackContext> response
             = handler.handleRequest(proxy, request, callbackContext, logger);


### PR DESCRIPTION
*Description of changes:*

* Fixed UpdateHandler to handle the following
   * Tag and UnTag as per the updates on the Tag.
   * Start or Stop canary depending on the model flag value.
* DeleteHandler now can delete a running canary by first stopping it.
* Fixed UnitTests


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
