### PR TITLE
Canary name is createOnlyProperty and increased callback seconds to 10

### DIFF
--- a/aws-synthetics-canary/aws-synthetics-canary.json
+++ b/aws-synthetics-canary/aws-synthetics-canary.json
@@ -22,7 +22,8 @@
         },
         "ArtifactS3Location": {
             "description": "Provide the s3 bucket output location for test results",
-            "type": "string"
+            "type": "string",
+            "pattern": "^(s3|S3)://"
         },
         "Schedule": {
             "description": "Frequency to run your canaries",
@@ -211,7 +212,9 @@
             "permissions": [
                 "synthetics:UpdateCanary",
                 "synthetics:StartCanary",
-                "synthetics:TagResource"
+                "synthetics:StopCanary",
+                "synthetics:TagResource",
+                "synthetics:UntagResource"
             ]
         },
         "read": {
@@ -236,12 +239,13 @@
         }
     },
     "additionalProperties": false,
+    "createOnlyProperties": [
+        "/properties/Name"
+    ],
     "primaryIdentifier": [
-        "/properties/Name",
-        "/properties/Id"
+        "/properties/Name"
     ],
     "readOnlyProperties": [
-        "/properties/Name",
         "/properties/Id",
         "/properties/State"
     ]

--- a/aws-synthetics-canary/src/main/java/com/amazon/synthetics/canary/CreateHandler.java
+++ b/aws-synthetics-canary/src/main/java/com/amazon/synthetics/canary/CreateHandler.java
@@ -16,7 +16,7 @@ import java.util.Map;
 public class CreateHandler extends BaseHandler<CallbackContext> {
     private static final String NODE_MODULES_DIR = "/nodejs/node_modules/";
     private static final String JS_SUFFIX = ".js";
-    private static final int DEFAULT_CALLBACK_DELAY_SECONDS = 5;
+    private static final int DEFAULT_CALLBACK_DELAY_SECONDS = 10;
     private static final int CALLBACK_DELAY_SECONDS_FOR_RUNNING_STATE = 30;
     private static final int MAX_RETRY_TIMES = 10; // 5min * 60 / 30 = 10
 

--- a/aws-synthetics-canary/src/test/java/com/amazon/synthetics/canary/CreateHandlerTest.java
+++ b/aws-synthetics-canary/src/test/java/com/amazon/synthetics/canary/CreateHandlerTest.java
@@ -185,7 +185,7 @@ public class CreateHandlerTest extends TestBase{
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.IN_PROGRESS);
         assertThat(response.getCallbackContext()).isEqualToComparingFieldByField(outputContext);
-        assertThat(response.getCallbackDelaySeconds()).isEqualTo(5);
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(10);
         assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
         assertThat(response.getResourceModels()).isNull();
         assertThat(response.getMessage()).isNull();


### PR DESCRIPTION

*Description of changes:*
* Updated the resource schema to have "Name" as create only property.
* Increased the callback seconds in create canary to 10 seconds from 5 seconds

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
