### PR TITLE
Removed timeout and retry policy from Synthetics client builder.

### DIFF
--- a/aws-synthetics-canary/src/main/java/com/amazon/synthetics/canary/ClientBuilder.java
+++ b/aws-synthetics-canary/src/main/java/com/amazon/synthetics/canary/ClientBuilder.java
@@ -10,30 +10,8 @@ import software.amazon.awssdk.core.retry.RetryPolicy;
 import software.amazon.cloudformation.LambdaWrapper;
 
 public class ClientBuilder {
-    /**
-     * The CFN handler timeout is 60s:
-     *  https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/resource-type-walkthrough.html
-     *    - https://sage.amazon.com/questions/767822
-     *    Synthetics regularly has long latencies (20s or higher) after creating and before starting as Lambdas are being
-     *    provisioned.
-     *    We'll use 3 30s timeouts, which should handle any initial-use latency and be within the CFN limi
-     * @return
-     */
-
-    static SyntheticsClient getClient() {
-        return SyntheticsClient
-                .builder()
-                .overrideConfiguration(
-                        ClientOverrideConfiguration
-                                .builder()
-                                .apiCallAttemptTimeout(Duration.ofSeconds(30))
-                                .apiCallTimeout(Duration.ofSeconds(59))
-                                .retryPolicy(RetryPolicy.builder().numRetries(3).build())
-                                .build())
-                // It is safe to close this client, which will not close the static http client
-                //   - https://docs.aws.amazon.com/sdk-for-java/v2/developer-guide/client-configuration-http.html
-                .httpClient(LambdaWrapper.HTTP_CLIENT)
-                .build();
+    public static SyntheticsClient getClient() {
+        return SyntheticsClient.builder().httpClient(LambdaWrapper.HTTP_CLIENT).build();
     }
 
     /**


### PR DESCRIPTION
*Description of changes:*
Removed timeout and retry policy from Synthetics client builder.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
