### PR TITLE
Fixed synthetics client in POM and usage of optional attributes

### DIFF
--- a/aws-synthetics-canary/aws-synthetics-canary.json
+++ b/aws-synthetics-canary/aws-synthetics-canary.json
@@ -77,7 +77,7 @@
                     "type" : "string"
                 }
             },
-            "required" : [ "Expression", "DurationInSeconds" ]
+            "required" : [ "Expression" ]
         },
         "Code" : {
             "type" : "object",
@@ -187,8 +187,7 @@
         "ExecutionRoleArn",
         "Schedule",
         "RuntimeVersion",
-        "StartCanaryAfterCreation",
-        "RunConfig"
+        "StartCanaryAfterCreation"
     ],
     "handlers": {
         "create": {

--- a/aws-synthetics-canary/pom.xml
+++ b/aws-synthetics-canary/pom.xml
@@ -20,9 +20,9 @@
 
     <dependencies>
        <dependency>
-           <groupId>com.amazonaws.services</groupId>
-           <artifactId>AWSSyntheticsJavaClient</artifactId>
-           <version>2.0-SNAPSHOT </version>
+           <groupId>software.amazon.awssdk</groupId>
+           <artifactId>synthetics</artifactId>
+           <version>2.13.23</version>
        </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>

--- a/aws-synthetics-canary/src/main/java/com/amazon/synthetics/canary/CreateHandler.java
+++ b/aws-synthetics-canary/src/main/java/com/amazon/synthetics/canary/CreateHandler.java
@@ -19,7 +19,7 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
     private static final int DEFAULT_CALLBACK_DELAY_SECONDS = 10;
     private static final int CALLBACK_DELAY_SECONDS_FOR_RUNNING_STATE = 30;
     private static final int MAX_RETRY_TIMES = 10; // 5min * 60 / 30 = 10
-    private  static final int DEFAULT_MEMORY_IN_MB = 960;
+    private static final int DEFAULT_MEMORY_IN_MB = 960;
 
     Logger logger;
     private AmazonWebServicesClientProxy clientProxy;
@@ -111,16 +111,27 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
                 .zipFile(model.getCode().getScript() != null ? ModelHelper.compressRawScript(model.getCode()) : null)
                 .build();
 
+
+        Long durationInSeconds = model.getSchedule().getDurationInSeconds() != null ?
+                Long.valueOf(model.getSchedule().getDurationInSeconds()) : null;
+
         final CanaryScheduleInput canaryScheduleInput = CanaryScheduleInput.builder()
                 .expression(model.getSchedule().getExpression())
-                .durationInSeconds(Long.valueOf((model.getSchedule().getDurationInSeconds()))).build();
-        final int memoryInMb = model.getRunConfig() != null && model.getRunConfig().getMemoryInMB() != null ?
-                model.getRunConfig().getMemoryInMB() : DEFAULT_MEMORY_IN_MB;
-
-        final CanaryRunConfigInput canaryRunConfigInput = CanaryRunConfigInput.builder()
-                .timeoutInSeconds(model.getRunConfig().getTimeoutInSeconds())
-                .memoryInMB(memoryInMb)
+                .durationInSeconds(durationInSeconds)
                 .build();
+
+        int memoryInMb = DEFAULT_MEMORY_IN_MB;
+        CanaryRunConfigInput canaryRunConfigInput = null;
+        if ( model.getRunConfig() != null ) {
+            // memoryInMb is optional input. Default value if no value is supplied
+            memoryInMb = model.getRunConfig().getMemoryInMB() != null ?
+                    model.getRunConfig().getMemoryInMB() : DEFAULT_MEMORY_IN_MB;
+
+            canaryRunConfigInput = CanaryRunConfigInput.builder()
+                    .timeoutInSeconds(model.getRunConfig().getTimeoutInSeconds())
+                    .memoryInMB(memoryInMb)
+                    .build();
+        }
 
         // VPC Config optional
         VpcConfigInput vpcConfigInput = null;

--- a/aws-synthetics-canary/src/main/java/com/amazon/synthetics/canary/UpdateHandler.java
+++ b/aws-synthetics-canary/src/main/java/com/amazon/synthetics/canary/UpdateHandler.java
@@ -145,6 +145,7 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
             getCanaryResponse = proxy.injectCredentialsAndInvokeV2(getCanaryRequest,
                     syntheticsClient::getCanary);
             Canary canary = getCanaryResponse.canary();
+
             handlerName = canary.code().handler();
             scheduleExpression = canary.schedule().expression();
             durationInSecs = canary.schedule().durationInSeconds().toString();
@@ -172,14 +173,16 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
                 durationInSecs = model.getSchedule().getDurationInSeconds();
             }
 
-            if (timeoutInSeconds != model.getRunConfig().getTimeoutInSeconds()) {
-                logger.log("Updating timeoutInSeconds");
-                timeoutInSeconds = model.getRunConfig().getTimeoutInSeconds();
-            }
+            if (model.getRunConfig() != null) {
+                if (timeoutInSeconds != model.getRunConfig().getTimeoutInSeconds()) {
+                    logger.log("Updating timeoutInSeconds");
+                    timeoutInSeconds = model.getRunConfig().getTimeoutInSeconds();
+                }
 
-            if (model.getRunConfig() != null && model.getRunConfig().getMemoryInMB() != null && memoryInMB != model.getRunConfig().getMemoryInMB()){
-                logger.log("Updating memory");
-                memoryInMB = model.getRunConfig().getMemoryInMB();
+                if (model.getRunConfig() != null && model.getRunConfig().getMemoryInMB() != null && memoryInMB != model.getRunConfig().getMemoryInMB()) {
+                    logger.log("Updating memory");
+                    memoryInMB = model.getRunConfig().getMemoryInMB();
+                }
             }
 
             if (model.getVPCConfig() != null && !vpcConfig.equals(model.getVPCConfig())) {


### PR DESCRIPTION
*Description of changes:*
* RunConfig is optional attribute.
* If RunConfig is specified, timeOutInSeconds needs to be specified.
* durationInSeconds is optional in Schedule structure.
* Updated aws-synthetics-canary.json model.
* Updated the Create and Update handlers.
* Updated the POM.xml to reference to the correct synthetics public sdk


* Testing:
 Locally tested using ```sam invoke local ```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
