### PR TITLE
Fix recreating a canary immediately after deleting it

### DIFF
--- a/aws-synthetics-canary/src/main/java/com/amazon/synthetics/canary/CallbackContext.java
+++ b/aws-synthetics-canary/src/main/java/com/amazon/synthetics/canary/CallbackContext.java
@@ -17,6 +17,7 @@ import software.amazon.cloudformation.exceptions.CfnNotStabilizedException;
 public class CallbackContext {
     private boolean canaryCreateStarted;
     private boolean canaryUpdateStarted;
+    private boolean canaryDeleteStarted;
     private String retryKey;
     private int remainingRetryCount;
     private CanaryState initialCanaryState;

--- a/aws-synthetics-canary/src/main/java/com/amazon/synthetics/canary/CanaryActionHandler.java
+++ b/aws-synthetics-canary/src/main/java/com/amazon/synthetics/canary/CanaryActionHandler.java
@@ -52,6 +52,9 @@ public abstract class CanaryActionHandler extends BaseHandler<CallbackContext> {
     protected Canary getCanaryOrThrow() {
         return CanaryHelper.getCanaryOrThrow(proxy, syntheticsClient, model);
     }
+    protected Canary getCanaryOrNull() {
+        return CanaryHelper.getCanaryOrNull(proxy, syntheticsClient, model.getName());
+    }
 
     protected void log(String message) {
         logger.log(message);

--- a/aws-synthetics-canary/src/main/java/com/amazon/synthetics/canary/CanaryHelper.java
+++ b/aws-synthetics-canary/src/main/java/com/amazon/synthetics/canary/CanaryHelper.java
@@ -43,7 +43,7 @@ public class CanaryHelper {
                                          SyntheticsClient syntheticsClient,
                                          String canaryName) {
         try {
-            return getCanaryOrThrow(proxy, syntheticsClient, canaryName);
+            return getCanary(proxy, syntheticsClient, canaryName);
         } catch (ResourceNotFoundException e) {
             return null;
         }
@@ -51,20 +51,26 @@ public class CanaryHelper {
     public static Canary getCanaryOrThrow(AmazonWebServicesClientProxy proxy,
                                           SyntheticsClient syntheticsClient,
                                           ResourceModel model) {
-        return getCanaryOrThrow(proxy, syntheticsClient, model.getPrimaryIdentifier().getString(ResourceModel.IDENTIFIER_KEY_NAME));
+        return getCanaryOrThrow(proxy, syntheticsClient, model.getName());
     }
     public static Canary getCanaryOrThrow(AmazonWebServicesClientProxy proxy,
                                           SyntheticsClient syntheticsClient,
                                           String canaryName) {
         try {
-            GetCanaryResponse response = proxy.injectCredentialsAndInvokeV2(
-                GetCanaryRequest.builder()
-                    .name(canaryName)
-                    .build(),
-                syntheticsClient::getCanary);
-            return response.canary();
+            return getCanary(proxy, syntheticsClient, canaryName);
         } catch (ResourceNotFoundException e) {
             throw new CfnNotFoundException(ResourceModel.TYPE_NAME, canaryName, e);
         }
+    }
+
+    private static Canary getCanary(AmazonWebServicesClientProxy proxy,
+                                    SyntheticsClient syntheticsClient,
+                                    String canaryName) {
+        GetCanaryResponse response = proxy.injectCredentialsAndInvokeV2(
+            GetCanaryRequest.builder()
+                .name(canaryName)
+                .build(),
+            syntheticsClient::getCanary);
+        return response.canary();
     }
 }


### PR DESCRIPTION
* `DELETE` will no longer return `SUCCESS` before the canary can be successfully recreated.
* Fixed a bug that could cause `DELETE` to appear to fail when it shouldn't.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
