### PR TITLE
Increase update timeout to prevent VPC failures

### DIFF
--- a/aws-synthetics-canary/src/main/java/com/amazon/synthetics/canary/UpdateHandler.java
+++ b/aws-synthetics-canary/src/main/java/com/amazon/synthetics/canary/UpdateHandler.java
@@ -11,7 +11,7 @@ import java.util.Map;
 
 public class UpdateHandler extends CanaryActionHandler {
     private static final int CALLBACK_DELAY_SECONDS = 10;
-    private static final int MAX_RETRY_TIMES = 10; // 5min * 60 / 30 = 10
+    private static final int MAX_RETRY_TIMES = 120;
     private static final String ADD_TAGS = "ADD_TAGS";
     private static final String REMOVE_TAGS = "REMOVE_TAGS";
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Increase timeout of the update handler to prevent errors from VPC attachment.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
