### PR TITLE
Fixed Python runtime packaging for the Lambda layer. TimeoutInSeconds…

### DIFF
--- a/aws-synthetics-canary/aws-synthetics-canary.json
+++ b/aws-synthetics-canary/aws-synthetics-canary.json
@@ -118,6 +118,7 @@
         },
         "Tag": {
             "description": "A key-value pair to associate with a resource.",
+            "additionalProperties" : false,
             "type": "object",
             "properties": {
                 "Key": {
@@ -181,6 +182,7 @@
                 },
                 "EnvironmentVariables" : {
                     "type" : "object",
+                    "additionalProperties": false,
                     "description" : "Environment variable key-value pairs.",
                     "patternProperties" : {
                         "[a-zA-Z][a-zA-Z0-9_]+" : {

--- a/aws-synthetics-canary/aws-synthetics-canary.json
+++ b/aws-synthetics-canary/aws-synthetics-canary.json
@@ -188,10 +188,7 @@
                         }
                     }
                 }
-            },
-            "required": [
-                "TimeoutInSeconds"
-            ]
+            }
         }
     },
     "required": [

--- a/aws-synthetics-canary/pom.xml
+++ b/aws-synthetics-canary/pom.xml
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
-            <version>2.0.2</version>
+            <version>2.0.4</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>

--- a/aws-synthetics-canary/src/main/java/com/amazon/synthetics/canary/CreateHandler.java
+++ b/aws-synthetics-canary/src/main/java/com/amazon/synthetics/canary/CreateHandler.java
@@ -98,7 +98,7 @@ public class CreateHandler extends CanaryActionHandler {
                 .s3Bucket(model.getCode().getS3Bucket())
                 .s3Key(model.getCode().getS3Key())
                 .s3Version(model.getCode().getS3ObjectVersion())
-                .zipFile(model.getCode().getScript() != null ? ModelHelper.compressRawScript(model.getCode()) : null)
+                .zipFile(model.getCode().getScript() != null ? ModelHelper.compressRawScript(model) : null)
                 .build();
 
         Long durationInSeconds = !Strings.isNullOrEmpty(model.getSchedule().getDurationInSeconds()) ?

--- a/aws-synthetics-canary/src/main/java/com/amazon/synthetics/canary/ModelHelper.java
+++ b/aws-synthetics-canary/src/main/java/com/amazon/synthetics/canary/ModelHelper.java
@@ -15,16 +15,23 @@ import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
 public class ModelHelper {
     private static final String NODE_MODULES_DIR = "/nodejs/node_modules/";
-    private static final String PYTHON_DIR = "/python/";
     private static final String JS_SUFFIX = ".js";
-    private static final String PY_SUFFIX = ".py";
+
     private static final String ADD_TAGS = "ADD_TAGS";
     private static final String REMOVE_TAGS = "REMOVE_TAGS";
+
+    // Python Runtime
+    private static final String PYTHON_DIR = "/python/";
+    private static final String PY_SUFFIX = ".py";
+    private static final String PYTHON_PATTERN = "^syn-python-*";
+    private static final Pattern python_pattern = Pattern.compile(PYTHON_PATTERN);
 
     public static ResourceModel constructModel(Canary canary, ResourceModel model) {
         Map<String, String> tags = canary.tags();
@@ -235,8 +242,9 @@ public class ModelHelper {
     }
 
     private static String getRuntimeLanguage(String runtimeVersion) {
+        Matcher python_matcher = python_pattern.matcher(runtimeVersion);
         // python runtime
-        if (runtimeVersion.matches("^syn-python-*")) {
+        if(python_matcher.matches()) {
             return "python";
         }
         // default

--- a/aws-synthetics-canary/src/main/java/com/amazon/synthetics/canary/ModelHelper.java
+++ b/aws-synthetics-canary/src/main/java/com/amazon/synthetics/canary/ModelHelper.java
@@ -234,19 +234,15 @@ public class ModelHelper {
             || vpcConfig.getSecurityGroupIds().isEmpty();
     }
 
-    private static String getRuntimeLanguage(String runtimeVersion){
-        String language="";
-        switch (runtimeVersion) {
-            case "syn-python-selenium-1.0":
-                language = "python";
-                break;
-            default:
-                language = "nodejs";
+    private static String getRuntimeLanguage(String runtimeVersion) {
+        // python runtime
+        if (runtimeVersion.matches("^syn-python-*")) {
+            return "python";
         }
-        return language;
+        // default
+        return "nodejs";
     }
 }
-
 
 
 

--- a/aws-synthetics-canary/src/main/java/com/amazon/synthetics/canary/UpdateHandler.java
+++ b/aws-synthetics-canary/src/main/java/com/amazon/synthetics/canary/UpdateHandler.java
@@ -228,7 +228,7 @@ public class UpdateHandler extends CanaryActionHandler {
                 .s3Bucket(model.getCode().getS3Bucket())
                 .s3Key(model.getCode().getS3Key())
                 .s3Version(model.getCode().getS3ObjectVersion())
-                .zipFile(model.getCode().getScript() != null ? ModelHelper.compressRawScript(model.getCode()) : null)
+                .zipFile(model.getCode().getScript() != null ? ModelHelper.compressRawScript(model) : null)
                 .build();
 
         final CanaryScheduleInput canaryScheduleInput = CanaryScheduleInput.builder()

--- a/aws-synthetics-canary/src/test/java/com/amazon/synthetics/canary/CreateHandlerTest.java
+++ b/aws-synthetics-canary/src/test/java/com/amazon/synthetics/canary/CreateHandlerTest.java
@@ -146,6 +146,58 @@ public class CreateHandlerTest extends TestBase {
     }
 
     @Test
+    public void handleRequest_SimpleSuccessRemovingOptionalValues() {
+        ResourceModel model = buildModel(false);
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        CanaryRunConfigOutput outputExpected = CanaryRunConfigOutput.builder()
+                .timeoutInSeconds(60)
+                .memoryInMB(1024)
+                .activeTracing(false)
+                .build();
+
+        final Canary canary = Canary.builder()
+                .name("canarytestname")
+                .code(codeOutputObjectForTesting())
+                .status(CanaryStatus.builder()
+                        .state("RUNNING")
+                        .build())
+                .schedule(canaryScheduleOutputForTesting())
+                .runConfig(outputExpected)
+                .build();
+
+        final CreateCanaryResponse createCanaryResponse = CreateCanaryResponse.builder()
+                .canary(canary)
+                .build();
+        final GetCanaryResponse getCanaryResponse = GetCanaryResponse.builder()
+                .canary(canary)
+                .build();
+        // final TagResourceRequest tagResourceRequest = TagResourceRequest.builder().resourceArn("arn:aws:synthetics:us-west-1:440056434621:canary:canarytestname").tags(sampleTags()).build();
+        final TagResourceResponse tagResourceResponse = TagResourceResponse.builder().build();
+        final CallbackContext inputContext = CallbackContext.builder().build();
+        final CallbackContext outputContext = CallbackContext.builder().canaryCreateStarted(true).build();
+
+        doReturn(createCanaryResponse,
+                getCanaryResponse,
+                tagResourceResponse).when(proxy).injectCredentialsAndInvokeV2(any(), any());
+
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, inputContext, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.IN_PROGRESS);
+        assertThat(response.getCallbackContext()).isEqualToComparingFieldByField(outputContext);
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(10);
+        assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
+        assertThat(response.getResourceModel().getRunConfig()).isNull();
+    }
+
+    @Test
     public void handleRequest_createCanary_inProgress() {
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
                 .desiredResourceState(buildModel())


### PR DESCRIPTION
… is now optional in RunConfig model.

*Issue #, if available:*

*Description of changes:*
* Fixed Python runtime packaging path in Lambda during canary run.
* TimeoutInSeconds attribute during RunConfig definition is now optional.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
