### PR TITLE
Remove the VPC from a canary when it is removed in the template.

### DIFF
--- a/aws-synthetics-canary/src/main/java/com/amazon/synthetics/canary/UpdateHandler.java
+++ b/aws-synthetics-canary/src/main/java/com/amazon/synthetics/canary/UpdateHandler.java
@@ -7,6 +7,7 @@ import software.amazon.cloudformation.Action;
 import software.amazon.cloudformation.exceptions.*;
 import software.amazon.cloudformation.proxy.*;
 
+import java.util.Collections;
 import java.util.Map;
 
 public class UpdateHandler extends CanaryActionHandler {
@@ -208,6 +209,11 @@ public class UpdateHandler extends CanaryActionHandler {
             vpcConfigInput = VpcConfigInput.builder()
                 .subnetIds(model.getVPCConfig().getSubnetIds())
                 .securityGroupIds(model.getVPCConfig().getSecurityGroupIds())
+                .build();
+        } else {
+            vpcConfigInput = VpcConfigInput.builder()
+                .subnetIds(Collections.emptyList())
+                .securityGroupIds(Collections.emptyList())
                 .build();
         }
 


### PR DESCRIPTION
If a canary is created with using the following template, and `UseVPC` is `true`, then it will be created with a VPC. If it is then updated so that `UseVPC` is `false`, the VPC should be removed. Currently the VPC is not removed. This change fixes that.

```yml
Canary:
  Type: AWS::Synthetics::Canary
  Properties:
    VPCConfig:
      !If
      - UseVPC
      -
        SecurityGroupIds:
        - !Ref VPCSecurityGroup
        SubnetIds:
        - !Ref PrivateSubnetA
        - !Ref PrivateSubnetB
      - !Ref AWS::NoValue
```



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
